### PR TITLE
Workaround for pypa/setuptools/issues/3548

### DIFF
--- a/templates/python/{{cookiecutter.repo_name}}/.github/workflows/python.yml
+++ b/templates/python/{{cookiecutter.repo_name}}/.github/workflows/python.yml
@@ -51,7 +51,7 @@ jobs:
     - name: "Install library ({{cookiecutter.package_name}})"
       #working-directory: ./
       run: |
-        pip install -e ".[all]"
+        pip install ".[all]"
     # Tests
     - name: "Tests and coverage ({{cookiecutter.package_name}})"
       run: |
@@ -68,14 +68,16 @@ jobs:
         black --check .
     # docs (API)
     - name: "Create documentation (API docs)"
+      if: ${{ "{{" }} matrix.python-version == '3.9' }}
       run: |
         pdoc --html -c latex_math=True --force --output-dir docs/api {{cookiecutter.namespace}}
     # docs (other)
     - name: "Create documentation (other)"
+      if: ${{ "{{" }} matrix.python-version == '3.9' }}
       run: |
         mkdocs build -c
     - name: Deploy docs
-      if: github.ref == 'refs/heads/main'
+      if: ${{ "{{" }} github.ref == 'refs/heads/main' && matrix.python-version == '3.9' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         # see https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#about-the-github_token-secret

--- a/templates/python/{{cookiecutter.repo_name}}/setup.py
+++ b/templates/python/{{cookiecutter.repo_name}}/setup.py
@@ -19,6 +19,7 @@ dev_deps = test_deps + [
     "wheel==0.37.1",
     # "black @ git+git://github.com/psf/black.git",
     "mkdocs==1.2.3",
+    "jinja2==3.0.3",
     # "portray @ git+git://github.com/myedibleenso/portray.git@issue/83",
     # "portray @ git+git://github.com/myedibleenso/portray.git@avoid-regressions",
     # "mkapi==1.0.14",


### PR DESCRIPTION
## Summary of changes
- Don't install package in editable mode
- Use pinned version of jinja2
- Only deploy docs for a single Python version